### PR TITLE
refactor(api): adaptar consumo do envelope padronizado { success, dat…

### DIFF
--- a/frontend/src/features/auth/services/auth.service.ts
+++ b/frontend/src/features/auth/services/auth.service.ts
@@ -1,3 +1,4 @@
+import { ApiResponse } from "../../../shared/types/apiResponse.dto.ts";
 import { UserDTO } from "../../../shared/types/user.dto.ts";
 import { loginSchemaType } from "../login/schema/login.schema.ts";
 import { privateApi, publicApi } from "../../../shared/services/axiosApi.ts";
@@ -18,7 +19,7 @@ export async function createUser(formData: registerSchemaType) {
 }
 
 export async function loginUser(body: loginSchemaType) {
-  await publicApi.post<UserDTO>(`${BASE_ENDPOINT}/login`, body);
+  await publicApi.post<ApiResponse<UserDTO>>(`${BASE_ENDPOINT}/login`, body);
 }
 
 export async function logoutUser() {

--- a/frontend/src/features/profile/services/user.service.ts
+++ b/frontend/src/features/profile/services/user.service.ts
@@ -1,13 +1,11 @@
 import { otpSchemaType } from "../../../shared/schema/otpCode.schema";
 import { privateApi } from "../../../shared/services/axiosApi";
+import { ApiResponse } from "../../../shared/types/apiResponse.dto";
 import { UserDTO } from "../../../shared/types/user.dto";
 
-export async function getUser() {
-  const user = await privateApi.get<UserDTO>("/v1/user");
-  return {
-    ...user.data,
-    firstName: user.data.username.split(" ")[0],
-  };
+export async function getUser(): Promise<UserDTO> {
+  const response = await privateApi.get<ApiResponse<UserDTO>>("/v1/user");
+  return response.data.data;
 }
 
 type UpdateUserBodyType = {

--- a/frontend/src/features/tasks/components/taskCard.module.css
+++ b/frontend/src/features/tasks/components/taskCard.module.css
@@ -20,6 +20,7 @@
   font-weight: 800;
   font-size: clamp(1.5rem, 2vw, 2rem);
   margin-bottom: 8px;
+  overflow-wrap: break-word;
 }
 
 .task_description {

--- a/frontend/src/features/tasks/hooks/useTask.query.ts
+++ b/frontend/src/features/tasks/hooks/useTask.query.ts
@@ -18,7 +18,8 @@ const useGetTasks = (user: boolean, params: GetTaskQueryParams) =>
       getTasks({ ...params, cursor: pageParam || undefined }),
     enabled: !!user,
     initialPageParam: null,
-    getNextPageParam: (lastPage) => lastPage.pagination.nextCursor ?? undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.data.pagination.nextCursor ?? undefined,
   });
 
 const useCreateTaskMutation = () => {

--- a/frontend/src/features/tasks/pages/HomePage.tsx
+++ b/frontend/src/features/tasks/pages/HomePage.tsx
@@ -23,8 +23,8 @@ const Home = () => {
     hasNextPage,
   });
 
-  const tasks = useMemo(
-    () => data?.pages.flatMap((pages) => pages.data) ?? [],
+  const dataMemo = useMemo(
+    () => data?.pages.flatMap((pages) => pages.data.tasks) ?? [],
     [data],
   );
 
@@ -39,8 +39,8 @@ const Home = () => {
 
   const filters = Object.values(StatusTask);
 
-  const hasNoTasksAtAll = !filterStatus && tasks.length === 0;
-  const hasNoTasksForFilter = !!filterStatus && tasks.length === 0;
+  const hasNoTasksAtAll = !filterStatus && dataMemo.length === 0;
+  const hasNoTasksForFilter = !!filterStatus && dataMemo.length === 0;
 
   return (
     <>
@@ -102,7 +102,7 @@ const Home = () => {
             )}
             <div className={styles.section_container}>
               {!isLoading &&
-                tasks.map((task) => (
+                dataMemo.map((task) => (
                   <TaskCard
                     key={task.id}
                     taskId={task.id}

--- a/frontend/src/features/tasks/services/task.service.ts
+++ b/frontend/src/features/tasks/services/task.service.ts
@@ -15,7 +15,9 @@ export async function getTasks(
       .filter(([, v]) => v !== undefined)
       .map(([k, v]) => [k, String(v)]),
   );
-  const response = await privateApi.get(`/v1/tasks?${urlSearchParams}`);
+  const response = await privateApi.get<GetTaskResponse>(
+    `/v1/tasks?${urlSearchParams}`,
+  );
   return response.data;
 }
 
@@ -32,7 +34,6 @@ export async function editTask({
   data: EditTaskPayload;
 }) {
   const response = await privateApi.patch(`/v1/tasks/${taskId}`, data);
-  console.log(response.data);
   return response;
 }
 

--- a/frontend/src/features/tasks/types/task.types.ts
+++ b/frontend/src/features/tasks/types/task.types.ts
@@ -1,3 +1,4 @@
+import type { ApiResponse } from "../../../shared/types/apiResponse.dto";
 import type {
   createTaskSchemaType,
   editTaskSchemaType,
@@ -14,20 +15,22 @@ type OptionsStatusTask = {
   value: keyof typeof StatusTask;
 };
 
-type GetTaskResponse = {
-  data: {
-    id: number;
-    title: string;
-    description: string | undefined;
-    status: StatusTask;
-    createdAt: Date;
-    updatedAt: Date;
-  }[];
+type Task = {
+  id: number;
+  title: string;
+  description: string | undefined;
+  status: StatusTask;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type GetTaskResponse = ApiResponse<{
+  tasks: Task[];
   pagination: {
     nextCursor: null;
     hasNextPage: number | null;
   };
-};
+}>;
 
 type CreateTaskPayload = createTaskSchemaType;
 

--- a/frontend/src/shared/types/apiResponse.dto.ts
+++ b/frontend/src/shared/types/apiResponse.dto.ts
@@ -1,0 +1,6 @@
+type ApiResponse<T> = {
+  success: boolean;
+  data: T;
+};
+
+export type { ApiResponse };


### PR DESCRIPTION
…a } da API

- adiciona tipo genérico ApiResponse<T> em shared/types
- restaura UserDTO como tipo plano e tipa getUser/loginUser com ApiResponse<UserDTO>
- ajusta GetTaskResponse para usar ApiResponse e tipa get de tasks
- atualiza useGetTasks e HomePage para acessar pagination/tasks via data.data
- remove console.log em editTask e adiciona overflow-wrap no título do TaskCard