### PR TITLE
fix: eliminar flash visual ao fechar dialogs com formulário

### DIFF
--- a/frontend/src/features/profile/components/DialogChangePassword.tsx
+++ b/frontend/src/features/profile/components/DialogChangePassword.tsx
@@ -1,17 +1,6 @@
-import styles from "./dialogChangePassword.module.css";
 import { Dialog, DialogPanel } from "@headlessui/react";
 import { SetStateAction } from "react";
-import CloseDialogBtn from "../../../shared/components/CloseDialogBtn";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  changePasswordSchema,
-  changePasswordSchemaType,
-} from "../schema/changePassword.schema";
-import LoadingCircleSpinner from "../../../shared/components/ui/LoadingCircleSpinner";
-import * as Service from "../../auth/services/auth.service";
-import { GoAlert } from "react-icons/go";
-import { useLogoutMutation } from "../../auth/hooks/useLogout.query";
+import FormChangePassword from "./FormChangePassword";
 
 const DialogChangePassword = ({
   openDialog,
@@ -20,109 +9,12 @@ const DialogChangePassword = ({
   openDialog: boolean;
   setOpenDialog: React.Dispatch<SetStateAction<boolean>>;
 }) => {
-  const {
-    handleSubmit,
-    register,
-    setError,
-    clearErrors,
-    formState: { isSubmitting, errors },
-    reset,
-  } = useForm({
-    resolver: zodResolver(changePasswordSchema),
-  });
-
-  const { mutateAsync: logoutMutationAsync } = useLogoutMutation();
-
-  async function sendRequest(data: changePasswordSchemaType) {
-    try {
-      await Service.changePassword(data);
-      setOpenDialog(false);
-      await logoutMutationAsync();
-    } catch (err) {
-      if (err instanceof Error)
-        setError("root", {
-          type: "server",
-          message: err.message,
-        });
-    }
-  }
-
   return (
-    <Dialog
-      open={openDialog}
-      onClose={() => {
-        reset();
-        setOpenDialog(false);
-      }}
-    >
+    <Dialog open={openDialog} onClose={() => setOpenDialog(false)}>
       <div className="overlay">
         <div className="container">
           <DialogPanel className="panel">
-            <form className={styles.form} onSubmit={handleSubmit(sendRequest)}>
-              <div className={styles.input_container}>
-                <label className={styles.label} htmlFor="currentPassword">
-                  Insira sua senha atual
-                </label>
-                <input
-                  className={styles.input}
-                  type="password"
-                  id="currentPassword"
-                  {...register("currentPassword", {
-                    onChange: () => clearErrors("root"),
-                  })}
-                />
-                {errors.currentPassword && (
-                  <span className={styles.error_message}>
-                    {errors.currentPassword.message}
-                  </span>
-                )}
-              </div>
-              <div className={styles.input_container}>
-                <label className={styles.label} htmlFor="newPassword">
-                  Insira sua nova senha
-                </label>
-                <input
-                  className={styles.input}
-                  type="password"
-                  id="newPassword"
-                  {...register("newPassword")}
-                />
-                {errors.newPassword && (
-                  <span className={styles.error_message}>
-                    {errors.newPassword.message}
-                  </span>
-                )}
-              </div>
-              <span className={styles.warning}>
-                <GoAlert />
-                Ao concluir a troca de senha, você será deslogado e
-                redirecionado para a tela de login novamente.
-              </span>
-              {errors.root && (
-                <span
-                  style={{ marginTop: "-10px" }}
-                  className={styles.error_message}
-                >
-                  {errors.root.message}
-                </span>
-              )}
-              <div className={styles.actions_container}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    reset();
-                    setOpenDialog(false);
-                  }}
-                  className={styles.cancel_btn}
-                >
-                  Cancelar alteração
-                </button>
-                <button type="submit" className={styles.change_btn}>
-                  {isSubmitting ? <LoadingCircleSpinner /> : "Alterar senha"}
-                </button>
-              </div>
-            </form>
-            <CloseDialogBtn resetForm={reset} setIsOpenDialog={setOpenDialog} />
+            <FormChangePassword setOpenDialog={setOpenDialog} />
           </DialogPanel>
         </div>
       </div>

--- a/frontend/src/features/profile/components/FormChangePassword.tsx
+++ b/frontend/src/features/profile/components/FormChangePassword.tsx
@@ -1,0 +1,114 @@
+import styles from "./dialogChangePassword.module.css";
+import { SetStateAction } from "react";
+import CloseDialogBtn from "../../../shared/components/CloseDialogBtn";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  changePasswordSchema,
+  changePasswordSchemaType,
+} from "../schema/changePassword.schema";
+import LoadingCircleSpinner from "../../../shared/components/ui/LoadingCircleSpinner";
+import * as Service from "../../auth/services/auth.service";
+import { GoAlert } from "react-icons/go";
+import { useLogoutMutation } from "../../auth/hooks/useLogout.query";
+
+const FormChangePassword = ({
+  setOpenDialog,
+}: {
+  setOpenDialog: React.Dispatch<SetStateAction<boolean>>;
+}) => {
+  const {
+    handleSubmit,
+    register,
+    setError,
+    clearErrors,
+    formState: { isSubmitting, errors },
+  } = useForm({
+    resolver: zodResolver(changePasswordSchema),
+  });
+
+  const { mutateAsync: logoutMutationAsync } = useLogoutMutation();
+
+  async function sendRequest(data: changePasswordSchemaType) {
+    try {
+      await Service.changePassword(data);
+      setOpenDialog(false);
+      await logoutMutationAsync();
+    } catch (err) {
+      if (err instanceof Error)
+        setError("root", {
+          type: "server",
+          message: err.message,
+        });
+    }
+  }
+
+  return (
+    <>
+      <form className={styles.form} onSubmit={handleSubmit(sendRequest)}>
+        <div className={styles.input_container}>
+          <label className={styles.label} htmlFor="currentPassword">
+            Insira sua senha atual
+          </label>
+          <input
+            className={styles.input}
+            type="password"
+            id="currentPassword"
+            {...register("currentPassword", {
+              onChange: () => clearErrors("root"),
+            })}
+          />
+          {errors.currentPassword && (
+            <span className={styles.error_message}>
+              {errors.currentPassword.message}
+            </span>
+          )}
+        </div>
+        <div className={styles.input_container}>
+          <label className={styles.label} htmlFor="newPassword">
+            Insira sua nova senha
+          </label>
+          <input
+            className={styles.input}
+            type="password"
+            id="newPassword"
+            {...register("newPassword")}
+          />
+          {errors.newPassword && (
+            <span className={styles.error_message}>
+              {errors.newPassword.message}
+            </span>
+          )}
+        </div>
+        <span className={styles.warning}>
+          <GoAlert />
+          Ao concluir a troca de senha, você será deslogado e redirecionado para
+          a tela de login novamente.
+        </span>
+        {errors.root && (
+          <span
+            style={{ marginTop: "-10px" }}
+            className={styles.error_message}
+          >
+            {errors.root.message}
+          </span>
+        )}
+        <div className={styles.actions_container}>
+          <button
+            type="button"
+            onClick={() => setOpenDialog(false)}
+            className={styles.cancel_btn}
+          >
+            Cancelar alteração
+          </button>
+          <button type="submit" className={styles.change_btn}>
+            {isSubmitting ? <LoadingCircleSpinner /> : "Alterar senha"}
+          </button>
+        </div>
+      </form>
+      <CloseDialogBtn setIsOpenDialog={setOpenDialog} />
+    </>
+  );
+};
+
+export default FormChangePassword;

--- a/frontend/src/features/profile/components/FormUpdateUser.tsx
+++ b/frontend/src/features/profile/components/FormUpdateUser.tsx
@@ -211,10 +211,7 @@ const FormUpdateUser = () => {
                 callbackResend={updateUserMutation}
                 emailInput={emailInput}
               />
-              <CloseDialogBtn
-                resetForm={updateUserForm.reset}
-                setIsOpenDialog={setIsOpenOtpDialog}
-              />
+              <CloseDialogBtn setIsOpenDialog={setIsOpenOtpDialog} />
             </DialogPanel>
           </div>
         </div>

--- a/frontend/src/features/profile/components/FormUploadAvatar.tsx
+++ b/frontend/src/features/profile/components/FormUploadAvatar.tsx
@@ -15,7 +15,6 @@ const FormUploadAvatar = ({
 }) => {
   const {
     register,
-    reset,
     handleSubmit,
     setError,
     control,
@@ -56,8 +55,6 @@ const FormUploadAvatar = ({
       await mutateAsync(formData, {
         onSuccess: () => setStateDialog(false),
       });
-
-      reset();
     } catch {
       setError("root", {
         type: "server",
@@ -116,10 +113,7 @@ const FormUploadAvatar = ({
           <button
             className={styles.cancel_btn}
             type="button"
-            onClick={() => {
-              reset();
-              setStateDialog(false);
-            }}
+            onClick={() => setStateDialog(false)}
           >
             Cancelar
           </button>

--- a/frontend/src/features/tasks/components/CreateTaskBtn.tsx
+++ b/frontend/src/features/tasks/components/CreateTaskBtn.tsx
@@ -1,5 +1,5 @@
 import { Dialog, DialogPanel } from "@headlessui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styles from "./createTaskBtn.module.css";
 import { RiAddFill } from "react-icons/ri";
 import { Controller, useForm } from "react-hook-form";
@@ -33,12 +33,13 @@ const CreateTaskBtn = () => {
     { name: "Concluído", value: "COMPLETED" },
   ];
 
+  useEffect(() => {
+    if (isOpen) reset();
+  }, [isOpen, reset]);
+
   async function onSubmit(data: createTaskSchemaType): Promise<void> {
     mutate(data, {
-      onSuccess: () => {
-        setIsOpen(false);
-        reset();
-      },
+      onSuccess: () => setIsOpen(false),
     });
   }
 
@@ -54,10 +55,7 @@ const CreateTaskBtn = () => {
       </div>
       <Dialog
         open={isOpen}
-        onClose={() => {
-          reset();
-          setIsOpen(false);
-        }}
+        onClose={() => setIsOpen(false)}
         className={styles.root}
       >
         <div className="overlay">
@@ -130,7 +128,7 @@ const CreateTaskBtn = () => {
                     </button>
                   </div>
                 </form>
-                <CloseDialogBtn resetForm={reset} setIsOpenDialog={setIsOpen} />
+                <CloseDialogBtn setIsOpenDialog={setIsOpen} />
               </div>
             </DialogPanel>
           </div>

--- a/frontend/src/features/tasks/components/EditTaskBtn.tsx
+++ b/frontend/src/features/tasks/components/EditTaskBtn.tsx
@@ -61,10 +61,7 @@ const EditTaskBtn = ({
     mutate(
       { taskId, data },
       {
-        onSuccess: () => {
-          setIsOpen(false);
-          reset();
-        },
+        onSuccess: () => setIsOpen(false),
         onError: (err) => console.log(err),
       },
     );
@@ -79,10 +76,7 @@ const EditTaskBtn = ({
       </div>
       <Dialog
         open={isOpen}
-        onClose={() => {
-          reset();
-          setIsOpen(false);
-        }}
+        onClose={() => setIsOpen(false)}
         className={styles.root}
       >
         <div className="overlay">
@@ -155,7 +149,7 @@ const EditTaskBtn = ({
                     </button>
                   </div>
                 </form>
-                <CloseDialogBtn resetForm={reset} setIsOpenDialog={setIsOpen} />
+                <CloseDialogBtn setIsOpenDialog={setIsOpen} />
               </div>
             </DialogPanel>
           </div>

--- a/frontend/src/shared/components/CloseDialogBtn.tsx
+++ b/frontend/src/shared/components/CloseDialogBtn.tsx
@@ -1,23 +1,17 @@
-import { FieldValues, UseFormReset } from "react-hook-form";
 import styles from "./closeDialogBtn.module.css";
 
 import React, { SetStateAction } from "react";
 import { IoCloseSharp } from "react-icons/io5";
 
-const CloseDialogBtn = <T extends FieldValues>({
-  resetForm,
+const CloseDialogBtn = ({
   setIsOpenDialog,
 }: {
-  resetForm: UseFormReset<T>;
   setIsOpenDialog: React.Dispatch<SetStateAction<boolean>>;
 }) => {
   return (
     <button
       className={styles.button_close}
-      onClick={() => {
-        resetForm();
-        setIsOpenDialog(false);
-      }}
+      onClick={() => setIsOpenDialog(false)}
     >
       <IoCloseSharp />
     </button>


### PR DESCRIPTION
- Resetar o form no mesmo tick do fechamento do Dialog causava um flash dos valores iniciais antes da animação de saída.
- Movido o reset para a abertura (via useEffect) nos dialogs cujo useForm vive no componente pai, e extraído FormChangePassword para um filho do Dialog - assim o useForm é desmontado junto com o componente no fechamento, sem reset manual e sem reter senhas em memória.