### PR TITLE
fix: padronizar cor herdada em buttons/links e ajustar responsividade…

### DIFF
--- a/frontend/src/shared/components/dropdownHeader.module.css
+++ b/frontend/src/shared/components/dropdownHeader.module.css
@@ -32,7 +32,7 @@
 .panel {
   position: absolute;
   margin-top: 8px;
-  width: 150px;
+  min-width: 150px;
   background-color: #ffffff;
   border: 1px solid #e5e5e5;
   border-radius: 8px;
@@ -73,14 +73,31 @@
   border: none;
   align-items: center;
   padding: 2px;
-}
-
-.container_items > button {
   font-size: 14px;
   cursor: pointer;
   font-family: var(--primary-font);
+  margin-left: 48px;
 }
 
 .container_items > button:hover {
   background-color: #f2f2f2;
+}
+
+@media (max-width: 780px) {
+  .panel {
+    padding: 14px 20px;
+  }
+
+  .username {
+    font-size: 1.175rem;
+  }
+
+  .container_items {
+    gap: 8px;
+  }
+
+  .container_items > button {
+    font-size: 1.1rem;
+    gap: 10px;
+  }
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -41,14 +41,6 @@ ul {
   text-decoration: none;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-}
-
 /* neutraliza o autofill do Chrome */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
@@ -72,6 +64,11 @@ button {
   background: none;
   margin: 0;
   padding: 0;
+  color: inherit;
+}
+
+a {
+  color: inherit;
 }
 
 * {


### PR DESCRIPTION
… do dropdownHeader

- Aplica color: inherit em button e a no global.css para evitar cor padrão azul no mobile
- Ajusta dropdownHeader para largura mínima e estilos responsivos abaixo de 780px